### PR TITLE
Fix message length calculation with UCS-2 encoding

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -351,6 +351,8 @@ class Client
                 // There are 133 octets available, but this would split the UCS the middle so use 132 instead
                 $csmsSplit = 132;
                 $message = mb_convert_encoding($message, 'UCS-2');
+                // Refresh message length with new encoding.
+                $msg_length = strlen($message);
                 break;
             case SMPP::DATA_CODING_DEFAULT:
                 // we send data in octets, but GSM 03.38 will be packed in septets (7-bit) by SMSC.


### PR DESCRIPTION
When using the library, I came across a small bug preventing some SMS from being sent.

Only messages between 70 and 140 characters would fail when sent with the UCS-2 encoding. If the message is short or long enough, it does not fall in this particular case.

By digging a bit I saw that message length is calculated before encoding conversion, creating a mismatch between the actual length of the string and the one used for comparison.

Thus adding a strlen after re-encoding the message fixes it.