### PR TITLE
Add missing inverted exclamation mark mapping

### DIFF
--- a/src/helpers/GsmEncoderHelper.php
+++ b/src/helpers/GsmEncoderHelper.php
@@ -97,7 +97,7 @@ class GsmEncoderHelper
             'я' => "\x04\x4F",
             // all \x2? removed
             // all \x3? removed
-            // all \x4? removed
+            '¡' => "\x40",
             'Ä' => "\x5B", 'Ö' => "\x5C", 'Ñ' => "\x5D", 'Ü' => "\x5E", '§' => "\x5F",
             '¿' => "\x60",
             'ä' => "\x7B", 'ö' => "\x7C", 'ñ' => "\x7D", 'ü' => "\x7E", 'à' => "\x7F",


### PR DESCRIPTION
This character is actually missing in the UTF-8 to GSM 03.38 encoder, as defined in the TXT conversion table linked in source code comments. It is required for proper Spanish grammar.