### PR TITLE
#6 fix PHP8 compatibility: socket is not resource but socket object

### DIFF
--- a/src/transport/Socket.php
+++ b/src/transport/Socket.php
@@ -224,7 +224,7 @@ class Socket
      */
     public function isOpen()
     {
-        if (!is_resource($this->socket)) {
+        if (!is_resource($this->socket) && !$this->socket instanceof \Socket) {
             return false;
         }
 


### PR DESCRIPTION
More information can be found here: https://php.watch/versions/8.0/sockets-sockets-addressinfo#sockets-is-resource